### PR TITLE
Add Edit Fuel Cost UI and API integration

### DIFF
--- a/src/addFuelCostToOrder/repository/UpdateCostFuelRepository.ts
+++ b/src/addFuelCostToOrder/repository/UpdateCostFuelRepository.ts
@@ -1,0 +1,35 @@
+import { fetchWithAuth } from '../../service/authService';
+
+const BASE_URL_API = import.meta.env.VITE_URL_BASE || 'http://127.0.0.1:8000';
+
+export interface UpdateCostFuelRequest {
+  cost_fuel?: number;
+  cost_gl?: number;
+  fuel_qty?: number;
+  distance?: number;
+  orders?: string[];
+}
+
+/**
+ * PUT /costfuels/{id_fuel}/
+ * Updates cost_fuel, fuel_qty, distance and/or orders.
+ * Orders are redistributed automatically by the backend.
+ */
+export async function updateCostFuel(
+  idFuel: number,
+  payload: UpdateCostFuelRequest
+): Promise<void> {
+  const res = await fetchWithAuth(`${BASE_URL_API}/costfuels/${idFuel}/`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  });
+
+  if (res.status === 401 || res.status === 403) {
+    throw new Error('Session expired');
+  }
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(body.messUser || body.messDev || `Error ${res.status}`);
+  }
+}

--- a/src/addFuelCostToOrder/ui/EditCostFuelDialog.tsx
+++ b/src/addFuelCostToOrder/ui/EditCostFuelDialog.tsx
@@ -364,7 +364,7 @@ const EditCostFuelDialog: React.FC<EditCostFuelDialogProps> = ({
               sx={{ mb: 3, borderRadius: 2 }}
             >
               {t('editCostFuel.distribution', {
-                count: formData.orders.length,
+                count: selectedOrders.length,
                 each: distributed.toFixed(2),
               })}
             </Alert>

--- a/src/addFuelCostToOrder/ui/EditCostFuelDialog.tsx
+++ b/src/addFuelCostToOrder/ui/EditCostFuelDialog.tsx
@@ -1,0 +1,518 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import React, { useState, useEffect, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Button,
+  TextField,
+  Box,
+  CircularProgress,
+  Typography,
+  Paper,
+  Divider,
+  InputAdornment,
+  Chip,
+  Alert,
+  Pagination,
+} from '@mui/material';
+import { X, Fuel, DollarSign, Droplets, MapPin, Pencil, Image, CheckCircle2, Search, Truck as TruckIcon } from 'lucide-react';
+import { LocalGasStation } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
+import { CostFuelWithOrders } from '../../resumeFuel/domain/CostFuelWithOrders';
+import { fetchOrdersReport } from '../../Home/data/repositoryOrdersReport';
+import { updateCostFuel } from '../repository/UpdateCostFuelRepository';
+
+interface EditCostFuelDialogProps {
+  open: boolean;
+  onClose: () => void;
+  costFuel: CostFuelWithOrders | null;
+  onSuccess?: () => void;
+}
+
+interface OrderOption {
+  key: string;
+  key_ref: string;
+  date: string;
+  client?: string;
+}
+
+const EditCostFuelDialog: React.FC<EditCostFuelDialogProps> = ({
+  open,
+  onClose,
+  costFuel,
+  onSuccess,
+}) => {
+  const { t } = useTranslation();
+  const { enqueueSnackbar } = useSnackbar();
+
+  const [loading, setLoading] = useState(false);
+  // String states for numeric fields so users can clear/type freely
+  const [costFuelStr, setCostFuelStr] = useState('0');
+  const [fuelQtyStr, setFuelQtyStr] = useState('0');
+  const [distanceStr, setDistanceStr] = useState('0');
+  const [costGlStr, setCostGlStr] = useState('0');
+  const [selectedOrders, setSelectedOrders] = useState<string[]>([]);
+
+  // Order search state
+  const [orderSearch, setOrderSearch] = useState('');
+  const [orderResults, setOrderResults] = useState<OrderOption[]>([]);
+  const [orderLoading, setOrderLoading] = useState(false);
+  const [orderPage, setOrderPage] = useState(1);
+  const [orderTotalPages, setOrderTotalPages] = useState(1);
+  const ORDER_PAGE_SIZE = 8;
+
+  // Pre-fill form when costFuel changes
+  useEffect(() => {
+    if (costFuel && open) {
+      setCostFuelStr(String(costFuel.cost_fuel));
+      setFuelQtyStr(String(costFuel.fuel_qty));
+      setDistanceStr(String(costFuel.distance));
+      setCostGlStr(String(costFuel.cost_gl));
+      setSelectedOrders(costFuel.order_cost_fuels.map(o => o.order_key));
+      setOrderSearch('');
+      setOrderResults([]);
+      setOrderPage(1);
+    }
+  }, [costFuel, open]);
+
+  // cost_fuel edited → derive cost_gl
+  const handleCostFuelChange = (val: string) => {
+    setCostFuelStr(val);
+    const costFuelNum = parseFloat(val) || 0;
+    const fuelQtyNum = parseFloat(fuelQtyStr) || 0;
+    if (fuelQtyNum > 0) {
+      setCostGlStr((costFuelNum / fuelQtyNum).toFixed(3));
+    }
+  };
+
+  // cost_gl edited → derive cost_fuel
+  const handleCostGlChange = (val: string) => {
+    setCostGlStr(val);
+    const costGlNum = parseFloat(val) || 0;
+    const fuelQtyNum = parseFloat(fuelQtyStr) || 0;
+    setCostFuelStr((costGlNum * fuelQtyNum).toFixed(2));
+  };
+
+  // fuel_qty edited → derive cost_fuel using current cost_gl
+  const handleFuelQtyChange = (val: string) => {
+    setFuelQtyStr(val);
+    const fuelQtyNum = parseFloat(val) || 0;
+    const costGlNum = parseFloat(costGlStr) || 0;
+    setCostFuelStr((costGlNum * fuelQtyNum).toFixed(2));
+  };
+
+  const searchOrders = useCallback(async (search: string, page: number) => {
+    if (!search.trim()) {
+      setOrderResults([]);
+      setOrderTotalPages(1);
+      return;
+    }
+    setOrderLoading(true);
+    try {
+      const today = new Date();
+      const weekNum = Math.ceil(
+        ((today.getTime() - new Date(today.getFullYear(), 0, 1).getTime()) / 86400000 +
+          new Date(today.getFullYear(), 0, 1).getDay() + 1) / 7
+      );
+      const response = await fetchOrdersReport(page, weekNum, today.getFullYear(), ORDER_PAGE_SIZE, search);
+      const results: OrderOption[] = (response.results ?? []).map((o: any) => ({
+        key: o.key,
+        key_ref: o.key_ref,
+        date: o.date,
+        client: o.customer?.first_name
+          ? `${o.customer.first_name} ${o.customer.last_name ?? ''}`.trim()
+          : undefined,
+      }));
+      setOrderResults(results);
+      setOrderTotalPages(Math.max(1, Math.ceil((response.count ?? 0) / ORDER_PAGE_SIZE)));
+    } catch {
+      enqueueSnackbar(t('editCostFuel.errorLoadingOrders'), { variant: 'error' });
+    } finally {
+      setOrderLoading(false);
+    }
+  }, [enqueueSnackbar, t]);
+
+  useEffect(() => {
+    const debounce = setTimeout(() => searchOrders(orderSearch, orderPage), 350);
+    return () => clearTimeout(debounce);
+  }, [orderSearch, orderPage, searchOrders]);
+
+  const toggleOrder = (key: string) => {
+    setSelectedOrders(prev =>
+      prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]
+    );
+  };
+
+  const removeOrder = (key: string) => {
+    setSelectedOrders(prev => prev.filter(k => k !== key));
+  };
+
+  const handleSubmit = async () => {
+    if (!costFuel) return;
+    const costFuelNum = parseFloat(costFuelStr) || 0;
+    const fuelQtyNum = parseFloat(fuelQtyStr) || 0;
+    const distanceNum = parseFloat(distanceStr) || 0;
+    const costGlNum = parseFloat(costGlStr) || 0;
+    if (costFuelNum <= 0) {
+      enqueueSnackbar(t('editCostFuel.validation.costRequired'), { variant: 'warning' });
+      return;
+    }
+    if (fuelQtyNum <= 0) {
+      enqueueSnackbar(t('editCostFuel.validation.fuelQtyRequired'), { variant: 'warning' });
+      return;
+    }
+    if (distanceNum <= 0) {
+      enqueueSnackbar(t('editCostFuel.validation.distanceRequired'), { variant: 'warning' });
+      return;
+    }
+    setLoading(true);
+    try {
+      await updateCostFuel(costFuel.id_fuel, {
+        cost_fuel: costFuelNum,
+        fuel_qty: fuelQtyNum,
+        distance: distanceNum,
+        cost_gl: costGlNum,
+        orders: selectedOrders,
+      });
+      enqueueSnackbar(t('editCostFuel.success'), { variant: 'success' });
+      onSuccess?.();
+      handleClose();
+    } catch (err: any) {
+      enqueueSnackbar(t('editCostFuel.error', { message: err.message }), { variant: 'error' });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!loading) {
+      setOrderSearch('');
+      setOrderResults([]);
+      onClose();
+    }
+  };
+
+  if (!costFuel) return null;
+
+  // Labels of selected orders (from search results + existing)
+  const selectedLabels = selectedOrders.map(key => {
+    const fromResults = orderResults.find(o => o.key === key);
+    if (fromResults) return { key, label: fromResults.key_ref };
+    const fromExisting = costFuel.order_cost_fuels.find(o => o.order_key === key);
+    if (fromExisting) return { key, label: fromExisting.order_key_ref };
+    return { key, label: key.slice(0, 8) + '…' };
+  });
+
+  const distributed = selectedOrders.length > 0 ? (parseFloat(costFuelStr) || 0) / selectedOrders.length : null;
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth="md"
+      fullWidth
+      sx={{ '& .MuiDialog-paper': { borderRadius: '16px', boxShadow: '0 24px 48px rgba(0,0,0,0.15)' } }}
+    >
+      {/* Header */}
+      <DialogTitle sx={{ p: 0 }}>
+        <Box
+          sx={{
+            background: 'linear-gradient(135deg, #0B2863 0%, #1e3a8a 100%)',
+            p: 3,
+            borderRadius: '16px 16px 0 0',
+            color: 'white',
+          }}
+        >
+          <Box display="flex" alignItems="center" justifyContent="space-between">
+            <Box display="flex" alignItems="center" gap={2}>
+              <Pencil size={28} />
+              <Box>
+                <Typography variant="h5" fontWeight="bold">
+                  {t('editCostFuel.title')}
+                </Typography>
+                <Typography variant="body2" sx={{ opacity: 0.85 }}>
+                  {t('editCostFuel.subtitle', {
+                    truck: costFuel.truck?.number_truck ?? '—',
+                    date: costFuel.date,
+                  })}
+                </Typography>
+              </Box>
+            </Box>
+            <Button
+              onClick={handleClose}
+              disabled={loading}
+              sx={{ color: 'white', minWidth: 'auto', p: 1, '&:hover': { bgcolor: 'rgba(255,255,255,0.15)' } }}
+            >
+              <X size={24} />
+            </Button>
+          </Box>
+
+          {/* Truck badge */}
+          <Box
+            mt={2}
+            display="flex"
+            alignItems="center"
+            gap={1.5}
+            sx={{ bgcolor: 'rgba(255,255,255,0.12)', borderRadius: 2, px: 2, py: 1.5, width: 'fit-content' }}
+          >
+            <TruckIcon size={18} />
+            <Typography variant="body2" fontWeight="bold">
+              {costFuel.truck?.number_truck} · {costFuel.truck?.name}
+            </Typography>
+            <Chip
+              label={costFuel.truck?.type}
+              size="small"
+              sx={{ bgcolor: 'rgba(255,255,255,0.25)', color: 'white', fontWeight: 700, fontSize: 11 }}
+            />
+          </Box>
+        </Box>
+      </DialogTitle>
+
+      <DialogContent sx={{ p: 0 }}>
+        <Box sx={{ p: 3 }}>
+
+          {/* ── Fuel Metrics Section ───────────────────────────────── */}
+          <Typography variant="h6" sx={{ color: '#0B2863', fontWeight: 700, mb: 2 }}>
+            <LocalGasStation sx={{ verticalAlign: 'middle', mr: 1, fontSize: 22 }} />
+            {t('editCostFuel.sections.metrics')}
+          </Typography>
+
+          <Paper elevation={0} sx={{ bgcolor: '#f8fafc', borderRadius: 2, p: 3, mb: 3 }}>
+            <Box display="grid" gridTemplateColumns="repeat(auto-fit, minmax(160px, 1fr))" gap={3}>
+
+              {/* cost_fuel */}
+              <TextField
+                label={t('editCostFuel.fields.costFuel')}
+                type="number"
+                value={costFuelStr}
+                onChange={(e) => handleCostFuelChange(e.target.value)}
+                inputProps={{ min: 0, step: 0.01 }}
+                InputProps={{
+                  startAdornment: <InputAdornment position="start"><DollarSign size={16} /></InputAdornment>,
+                }}
+                variant="outlined"
+                size="small"
+                fullWidth
+                sx={{ bgcolor: 'white' }}
+                helperText={t('editCostFuel.fields.costFuelHelper', { original: costFuel.cost_fuel.toFixed(2) })}
+              />
+
+              {/* fuel_qty */}
+              <TextField
+                label={t('editCostFuel.fields.fuelQty')}
+                type="number"
+                value={fuelQtyStr}
+                onChange={(e) => handleFuelQtyChange(e.target.value)}
+                inputProps={{ min: 0, step: 0.1 }}
+                InputProps={{
+                  endAdornment: <InputAdornment position="end"><Droplets size={16} /> gl</InputAdornment>,
+                }}
+                variant="outlined"
+                size="small"
+                fullWidth
+                sx={{ bgcolor: 'white' }}
+                helperText={t('editCostFuel.fields.fuelQtyHelper', { original: costFuel.fuel_qty.toFixed(1) })}
+              />
+
+              {/* distance */}
+              <TextField
+                label={t('editCostFuel.fields.distance')}
+                type="number"
+                value={distanceStr}
+                onChange={(e) => setDistanceStr(e.target.value)}
+                inputProps={{ min: 0, step: 1 }}
+                InputProps={{
+                  endAdornment: <InputAdornment position="end"><MapPin size={16} /> mi</InputAdornment>,
+                }}
+                variant="outlined"
+                size="small"
+                fullWidth
+                sx={{ bgcolor: 'white' }}
+                helperText={t('editCostFuel.fields.distanceHelper', { original: costFuel.distance.toLocaleString() })}
+              />
+
+            </Box>
+
+            {/* cost_gl: editable, auto-derived */}
+            <Box mt={2}>
+              <TextField
+                label={t('editCostFuel.fields.costGl')}
+                type="number"
+                value={costGlStr}
+                onChange={(e) => handleCostGlChange(e.target.value)}
+                inputProps={{ min: 0, step: 0.001 }}
+                InputProps={{
+                  startAdornment: <InputAdornment position="start"><Fuel size={16} /></InputAdornment>,
+                  endAdornment: <InputAdornment position="end">/gl</InputAdornment>,
+                }}
+                variant="outlined"
+                size="small"
+                sx={{ bgcolor: 'white', width: 200 }}
+                helperText={t('editCostFuel.fields.costGlHelper', { original: costFuel.cost_gl.toFixed(3) })}
+              />
+            </Box>
+          </Paper>
+
+          {/* ── Distribution preview ───────────────────────────────── */}
+          {distributed !== null && (
+            <Alert
+              icon={<CheckCircle2 size={18} />}
+              severity="info"
+              sx={{ mb: 3, borderRadius: 2 }}
+            >
+              {t('editCostFuel.distribution', {
+                count: formData.orders.length,
+                each: distributed.toFixed(2),
+              })}
+            </Alert>
+          )}
+
+          <Divider sx={{ mb: 3 }} />
+
+          {/* ── Orders Section ─────────────────────────────────────── */}
+          <Typography variant="h6" sx={{ color: '#0B2863', fontWeight: 700, mb: 2 }}>
+            <Image size={20} style={{ verticalAlign: 'middle', marginRight: 8 }} />
+            {t('editCostFuel.sections.orders')}
+          </Typography>
+
+          {/* Selected order chips */}
+          {selectedLabels.length > 0 && (
+            <Box display="flex" flexWrap="wrap" gap={1} mb={2}>
+              {selectedLabels.map(({ key, label }) => (
+                <Chip
+                  key={key}
+                  label={label}
+                  onDelete={() => removeOrder(key)}
+                  deleteIcon={<X size={14} />}
+                  sx={{
+                    bgcolor: '#0B2863',
+                    color: 'white',
+                    fontWeight: 600,
+                    '& .MuiChip-deleteIcon': { color: 'rgba(255,255,255,0.7)', '&:hover': { color: 'white' } },
+                  }}
+                />
+              ))}
+            </Box>
+          )}
+
+          {/* Order search */}
+          <TextField
+            fullWidth
+            size="small"
+            placeholder={t('editCostFuel.orderSearch.placeholder')}
+            value={orderSearch}
+            onChange={(e) => { setOrderSearch(e.target.value); setOrderPage(1); }}
+            InputProps={{
+              startAdornment: (
+                <InputAdornment position="start">
+                  <Search size={16} color="#6b7280" />
+                </InputAdornment>
+              ),
+              endAdornment: orderLoading
+                ? <InputAdornment position="end"><CircularProgress size={16} /></InputAdornment>
+                : null,
+            }}
+            sx={{ mb: 1.5 }}
+          />
+
+          {/* Order results list */}
+          {orderResults.length > 0 && (
+            <Paper variant="outlined" sx={{ borderRadius: 2, overflow: 'hidden', mb: 1 }}>
+              {orderResults.map((order) => {
+                const selected = selectedOrders.includes(order.key);
+                return (
+                  <Box
+                    key={order.key}
+                    onClick={() => toggleOrder(order.key)}
+                    sx={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      px: 2,
+                      py: 1.2,
+                      cursor: 'pointer',
+                      bgcolor: selected ? '#EEF2FF' : 'white',
+                      borderLeft: selected ? '4px solid #0B2863' : '4px solid transparent',
+                      transition: 'all 0.15s',
+                      '&:hover': { bgcolor: selected ? '#E0E7FF' : '#f8fafc' },
+                      '&:not(:last-child)': { borderBottom: '1px solid #f1f5f9' },
+                    }}
+                  >
+                    <Box>
+                      <Typography variant="body2" fontWeight={700} sx={{ color: '#0B2863' }}>
+                        {order.key_ref}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {order.date}{order.client ? ` · ${order.client}` : ''}
+                      </Typography>
+                    </Box>
+                    {selected && <CheckCircle2 size={18} color="#0B2863" />}
+                  </Box>
+                );
+              })}
+            </Paper>
+          )}
+
+          {orderSearch.trim() && !orderLoading && orderResults.length === 0 && (
+            <Typography variant="caption" color="text.secondary" sx={{ pl: 1 }}>
+              {t('editCostFuel.orderSearch.noResults')}
+            </Typography>
+          )}
+
+          {orderTotalPages > 1 && (
+            <Box display="flex" justifyContent="center" mt={1}>
+              <Pagination
+                count={orderTotalPages}
+                page={orderPage}
+                size="small"
+                onChange={(_, p) => setOrderPage(p)}
+                sx={{ '& .MuiPaginationItem-root': { color: '#0B2863' } }}
+              />
+            </Box>
+          )}
+
+        </Box>
+      </DialogContent>
+
+      {/* Footer */}
+      <DialogActions
+        sx={{ px: 3, py: 2, borderTop: '1px solid #e2e8f0', justifyContent: 'space-between' }}
+      >
+        <Typography variant="caption" color="text.secondary">
+          ID: {costFuel.id_fuel} · {t('editCostFuel.footer.ordersCount', { count: selectedOrders.length })}
+        </Typography>
+        <Box display="flex" gap={1.5}>
+          <Button
+            onClick={handleClose}
+            disabled={loading}
+            variant="outlined"
+            sx={{ borderColor: '#0B2863', color: '#0B2863', borderRadius: 2, textTransform: 'none', fontWeight: 600 }}
+          >
+            {t('editCostFuel.cancel')}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={loading}
+            variant="contained"
+            startIcon={loading ? <CircularProgress size={16} color="inherit" /> : <Pencil size={16} />}
+            sx={{
+              bgcolor: '#0B2863',
+              '&:hover': { bgcolor: '#051f47' },
+              borderRadius: 2,
+              textTransform: 'none',
+              fontWeight: 700,
+              px: 3,
+            }}
+          >
+            {loading ? t('editCostFuel.saving') : t('editCostFuel.save')}
+          </Button>
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+export default EditCostFuelDialog;

--- a/src/i18n/locales/en/en_translation.json
+++ b/src/i18n/locales/en/en_translation.json
@@ -711,6 +711,14 @@
     "searchLabel": "Search by Key Ref or Shipper",
     "searchPlaceholder": "Enter key ref or shipper name...",
     "searchHelper": "Type to search across key references and shipper names",
+    "searchModeGlobal": "Global",
+    "searchModeLocal": "Local",
+    "searchModeGlobalHint": "Search via the API (filters all pages)",
+    "searchModeLocalHint": "Filter only the current page data",
+    "searchPlaceholderGlobal": "Search keyref, shipper, income, expense...",
+    "searchPlaceholderLocal": "Filter visible rows...",
+    "searchHelperGlobal": "Searches across all records via the server (keyref, shipper, income, expense)",
+    "searchHelperLocal": "Filters only the rows currently loaded on screen",
     "weekSummary": "Week Summary",
     "records": "Records",
     "income": "Income",
@@ -1232,6 +1240,43 @@
       "error": "Error: {{message}}"
     }
   },
+  "editCostFuel": {
+    "title": "Edit Fuel Cost",
+    "subtitle": "Truck #{{truck}} · {{date}}",
+    "sections": {
+      "metrics": "Fuel Metrics",
+      "orders": "Associated Orders"
+    },
+    "fields": {
+      "costFuel": "Total Cost",
+      "costFuelHelper": "Original: ${{original}}",
+      "fuelQty": "Fuel Quantity",
+      "fuelQtyHelper": "Original: {{original}} gl",
+      "distance": "Distance",
+      "distanceHelper": "Original: {{original}} mi",
+      "costGl": "Cost per Gallon",
+      "costGlHelper": "Original: ${{original}}/gl"
+    },
+    "distribution": "{{count}} order(s) will each receive ${{each}}",
+    "orderSearch": {
+      "placeholder": "Search orders by reference or client...",
+      "noResults": "No orders found for this search"
+    },
+    "validation": {
+      "costRequired": "Total cost must be greater than 0",
+      "fuelQtyRequired": "Fuel quantity must be greater than 0",
+      "distanceRequired": "Distance must be greater than 0"
+    },
+    "success": "Fuel cost updated successfully",
+    "error": "Error updating fuel cost: {{message}}",
+    "errorLoadingOrders": "Error loading orders",
+    "cancel": "Cancel",
+    "save": "Save Changes",
+    "saving": "Saving...",
+    "footer": {
+      "ordersCount": "{{count}} order(s) assigned"
+    }
+  },
   "resumeFuelTable": {
     "title": "Fuel Cost Records",
     "exportAll": "Export All",
@@ -1276,6 +1321,10 @@
         "distance": "Distance"
       },
       "empty": "No orders associated with this fuel cost"
+    },
+    "editButton": {
+      "label": "Edit",
+      "tooltip": "Edit fuel cost"
     },
     "footer": {
       "total": "Total: {{count}} fuel records | Selected: {{selected}}",

--- a/src/i18n/locales/es/es_translation.json
+++ b/src/i18n/locales/es/es_translation.json
@@ -712,6 +712,14 @@
     "searchLabel": "Buscar por Ref. Clave o Transportista",
     "searchPlaceholder": "Ingresa ref. clave o nombre del transportista...",
     "searchHelper": "Escribe para buscar entre referencias y transportistas",
+    "searchModeGlobal": "Global",
+    "searchModeLocal": "Local",
+    "searchModeGlobalHint": "Busca mediante la API (filtra todas las páginas)",
+    "searchModeLocalHint": "Filtra solo los datos cargados en pantalla",
+    "searchPlaceholderGlobal": "Buscar keyref, transportista, ingreso, gasto...",
+    "searchPlaceholderLocal": "Filtrar filas visibles...",
+    "searchHelperGlobal": "Busca en todos los registros del servidor (keyref, transportista, ingreso, gasto)",
+    "searchHelperLocal": "Filtra solo las filas cargadas actualmente en pantalla",
     "weekSummary": "Resumen de Semana",
     "records": "Registros",
     "income": "Ingreso",
@@ -1191,6 +1199,43 @@
       "error": "Error: {{message}}"
     }
   },
+  "editCostFuel": {
+    "title": "Editar Costo de Combustible",
+    "subtitle": "Camión #{{truck}} · {{date}}",
+    "sections": {
+      "metrics": "Métricas de Combustible",
+      "orders": "Órdenes Asociadas"
+    },
+    "fields": {
+      "costFuel": "Costo Total",
+      "costFuelHelper": "Original: ${{original}}",
+      "fuelQty": "Cantidad de Combustible",
+      "fuelQtyHelper": "Original: {{original}} gl",
+      "distance": "Distancia",
+      "distanceHelper": "Original: {{original}} mi",
+      "costGl": "Costo por Galón",
+      "costGlHelper": "Original: ${{original}}/gl"
+    },
+    "distribution": "{{count}} orden(es) recibirán ${{each}} cada una",
+    "orderSearch": {
+      "placeholder": "Buscar órdenes por referencia o cliente...",
+      "noResults": "No se encontraron órdenes para esta búsqueda"
+    },
+    "validation": {
+      "costRequired": "El costo total debe ser mayor a 0",
+      "fuelQtyRequired": "La cantidad de combustible debe ser mayor a 0",
+      "distanceRequired": "La distancia debe ser mayor a 0"
+    },
+    "success": "Costo de combustible actualizado exitosamente",
+    "error": "Error al actualizar el costo: {{message}}",
+    "errorLoadingOrders": "Error al cargar las órdenes",
+    "cancel": "Cancelar",
+    "save": "Guardar Cambios",
+    "saving": "Guardando...",
+    "footer": {
+      "ordersCount": "{{count}} orden(es) asignada(s)"
+    }
+  },
   "summaryCostTable": {
     "columns": {
       "actions": "Acciones",
@@ -1284,6 +1329,10 @@
         "distance": "Distancia"
       },
       "empty": "No hay órdenes asociadas a este costo de combustible"
+    },
+    "editButton": {
+      "label": "Editar",
+      "tooltip": "Editar costo de combustible"
     },
     "footer": {
       "total": "Total: {{count}} registros | Seleccionados: {{selected}}",

--- a/src/resumeFuel/ui/components/ResumeFuelTable.tsx
+++ b/src/resumeFuel/ui/components/ResumeFuelTable.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useState, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ArrowUp, ArrowDown, ArrowUpDown, Download, Inbox, Eye, X, Image as ImageIcon, Truck as TruckIcon, MapPin, ChevronDown, ChevronRight, Package } from 'lucide-react';
+import { ArrowUp, ArrowDown, ArrowUpDown, Download, Inbox, Eye, X, Image as ImageIcon, Truck as TruckIcon, MapPin, ChevronDown, ChevronRight, Package, Pencil } from 'lucide-react';
 import { WeeklyFuelDataResponse, CostFuelWithOrders } from '../../domain/CostFuelWithOrders';
 import { generateCsv, download, mkConfig } from 'export-to-csv';
 
@@ -155,7 +155,8 @@ const csvConfig = mkConfig({
 export const ResumeFuelTable: React.FC<{
   data: WeeklyFuelDataResponse | null;
   isLoading: boolean;
-}> = ({ data, isLoading }) => {
+  onEditCostFuel?: (costFuel: CostFuelWithOrders) => void;
+}> = ({ data, isLoading, onEditCostFuel }) => {
   const { t } = useTranslation();
   const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
   const [sortConfig, setSortConfig] = useState<SortConfig>({ key: null, direction: null });
@@ -480,23 +481,37 @@ export const ResumeFuelTable: React.FC<{
                                     <Package size={18} />
                                     {t('resumeFuelTable.orders.title', { count: row.orders_count })}
                                   </h4>
-                                  {row.image_url && (
-                                    <button
-                                      onClick={() => setPreviewImage({ 
-                                        url: row.image_url!, 
-                                        fuelData: { 
-                                          cost_gl: row.cost_gl, 
-                                          fuel_qty: row.fuel_qty, 
-                                          cost_fuel: row.cost_fuel,
-                                          date: row.date
-                                        }
-                                      })}
-                                      className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg flex items-center gap-2 text-sm font-semibold transition-colors"
-                                    >
-                                      <Eye size={16} />
-                                      {t('resumeFuelTable.receipt.viewButton')}
-                                    </button>
-                                  )}
+                                  <div className="flex items-center gap-2">
+                                    {/* Edit button */}
+                                    {onEditCostFuel && (
+                                      <button
+                                        onClick={(e) => { e.stopPropagation(); onEditCostFuel(row); }}
+                                        className="px-4 py-2 border-2 rounded-lg flex items-center gap-2 text-sm font-semibold transition-all hover:shadow-md"
+                                        style={{ borderColor: '#F09F52', color: '#F09F52', backgroundColor: 'white' }}
+                                        title={t('resumeFuelTable.editButton.tooltip')}
+                                      >
+                                        <Pencil size={15} />
+                                        {t('resumeFuelTable.editButton.label')}
+                                      </button>
+                                    )}
+                                    {row.image_url && (
+                                      <button
+                                        onClick={() => setPreviewImage({ 
+                                          url: row.image_url!, 
+                                          fuelData: { 
+                                            cost_gl: row.cost_gl, 
+                                            fuel_qty: row.fuel_qty, 
+                                            cost_fuel: row.cost_fuel,
+                                            date: row.date
+                                          }
+                                        })}
+                                        className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg flex items-center gap-2 text-sm font-semibold transition-colors"
+                                      >
+                                        <Eye size={16} />
+                                        {t('resumeFuelTable.receipt.viewButton')}
+                                      </button>
+                                    )}
+                                  </div>
                                 </div>
                                 
                                 {row.order_cost_fuels && row.order_cost_fuels.length > 0 ? (

--- a/src/resumeFuel/ui/pages/ResumeFuel.tsx
+++ b/src/resumeFuel/ui/pages/ResumeFuel.tsx
@@ -2,10 +2,11 @@ import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import ResumeFuelTable from '../components/ResumeFuelTable';
 import { ResumeFuelService } from '../../data/ResumeFuelServices';
-import { WeeklyFuelDataResponse } from '../../domain/CostFuelWithOrders';
+import { WeeklyFuelDataResponse, CostFuelWithOrders } from '../../domain/CostFuelWithOrders';
 import YearPicker from '../../../components/YearPicker';
 import WeekPicker from '../../../components/WeekPicker';
 import CreateCostFuelDialog from '../../../addFuelCostToOrder/ui/CreateCostFuelDialog';
+import EditCostFuelDialog from '../../../addFuelCostToOrder/ui/EditCostFuelDialog';
 import { Plus, Truck } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
@@ -17,6 +18,7 @@ const ResumeFuel: React.FC = () => {
   const [currentWeek, setCurrentWeek] = useState<number>(1);
   const [currentYear, setCurrentYear] = useState<number>(new Date().getFullYear());
   const [createDialogOpen, setCreateDialogOpen] = useState<boolean>(false);
+  const [editCostFuel, setEditCostFuel] = useState<CostFuelWithOrders | null>(null);
 
   const resumeFuelServices = new ResumeFuelService();
 
@@ -164,6 +166,7 @@ const ResumeFuel: React.FC = () => {
       <ResumeFuelTable
         data={resumeFuel}
         isLoading={isLoading}
+        onEditCostFuel={setEditCostFuel}
       />
 
       {/* Create Fuel Cost Dialog */}
@@ -172,6 +175,17 @@ const ResumeFuel: React.FC = () => {
         onClose={() => setCreateDialogOpen(false)}
         onSuccess={() => {
           setCreateDialogOpen(false);
+          fetchResumeFuel(currentWeek, currentYear);
+        }}
+      />
+
+      {/* Edit Fuel Cost Dialog */}
+      <EditCostFuelDialog
+        open={!!editCostFuel}
+        costFuel={editCostFuel}
+        onClose={() => setEditCostFuel(null)}
+        onSuccess={() => {
+          setEditCostFuel(null);
           fetchResumeFuel(currentWeek, currentYear);
         }}
       />

--- a/src/statement/data/StatementRepository.tsx
+++ b/src/statement/data/StatementRepository.tsx
@@ -6,21 +6,26 @@ import { fetchWithAuth, logout } from '../../service/authService';
 const BASE_URL_API = import.meta.env.VITE_URL_BASE || 'http://127.0.0.1:8000';
 
 /**
- * Fetch statements by week with optional year and pagination.
+ * Fetch statements by week with optional year, pagination and search.
+ * - When `search` is provided and `week` is undefined: searches across all weeks for the year.
+ * - At least one of `week` or `search` must be present (backend enforces this).
+ * GET {{BASE_URL_API}}/statements/by-week/?year=2025&search=ACME
  * GET {{BASE_URL_API}}/statements/by-week/?week=30&year=2025&page_size=20&page=1
  */
 export async function fetchStatementsByWeek(
-  week: number,
+  week: number | undefined,
   year?: number,
   page: number = 1,
-  pageSize: number = 20
+  pageSize: number = 20,
+  search?: string
 ): Promise<StatementsByWeekResponse> {
   try {
     const params = new URLSearchParams();
-    params.append('week', String(week));
+    if (week !== undefined) params.append('week', String(week));
     if (year !== undefined) params.append('year', String(year));
     params.append('page', String(page));
     params.append('page_size', String(pageSize));
+    if (search && search.trim()) params.append('search', search.trim());
 
     const url = `${BASE_URL_API}/statements/by-week/?${params.toString()}`;
     console.log('Fetching statements by week from URL:', url);

--- a/src/statement/ui/StatementFilters.tsx
+++ b/src/statement/ui/StatementFilters.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { CalendarDays, FileText, DollarSign, TrendingUp, TrendingDown, Filter, Calendar } from 'lucide-react';
+import { CalendarDays, FileText, DollarSign, TrendingUp, TrendingDown, Filter, Calendar, Globe, MonitorSmartphone } from 'lucide-react';
 import { WeekSummary } from '../domain/StatementModels';
 import WeekPicker from '../../components/WeekPicker';
 
@@ -9,9 +9,11 @@ interface StatementFiltersProps {
   year: number;
   weekRange: { start: string; end: string };
   searchQuery: string;
+  searchMode: 'global' | 'local';
   onWeekChange: (week: number) => void;
   onYearChange: (year: number) => void;
   onSearchQueryChange: (query: string) => void;
+  onSearchModeChange: (mode: 'global' | 'local') => void;
   weekSummary: WeekSummary | null;
   totalRecords: number;
 }
@@ -22,8 +24,8 @@ const COLORS = {
 };
 
 export const StatementFilters: React.FC<StatementFiltersProps> = ({
-  week, year, weekRange, searchQuery,
-  onWeekChange, onYearChange, onSearchQueryChange,
+  week, year, weekRange, searchQuery, searchMode,
+  onWeekChange, onYearChange, onSearchQueryChange, onSearchModeChange,
   weekSummary, totalRecords,
 }) => {
   const { t } = useTranslation();
@@ -102,26 +104,61 @@ export const StatementFilters: React.FC<StatementFiltersProps> = ({
       <div className="border-t my-3" style={{ borderColor: COLORS.primary }} />
 
       {/* Search */}
-      <div className="flex items-center gap-2 mb-2">
-        <Filter size={14} className="flex-shrink-0" style={{ color: COLORS.primary }} />
-        <h4 className="text-xs sm:text-sm font-bold" style={{ color: COLORS.primary }}>
-          {t('statementFilters.searchTitle')}
-        </h4>
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2">
+          <Filter size={14} className="flex-shrink-0" style={{ color: COLORS.primary }} />
+          <h4 className="text-xs sm:text-sm font-bold" style={{ color: COLORS.primary }}>
+            {t('statementFilters.searchTitle')}
+          </h4>
+        </div>
+
+        {/* Mode toggle */}
+        <div className="flex items-center rounded-lg border overflow-hidden" style={{ borderColor: COLORS.primary }}>
+          <button
+            type="button"
+            onClick={() => onSearchModeChange('global')}
+            className="flex items-center gap-1 px-3 py-1.5 text-xs font-semibold transition-colors"
+            style={{
+              backgroundColor: searchMode === 'global' ? COLORS.primary : 'transparent',
+              color: searchMode === 'global' ? '#fff' : COLORS.primary,
+            }}
+            title={t('statementFilters.searchModeGlobalHint')}
+          >
+            <Globe size={12} />
+            {t('statementFilters.searchModeGlobal')}
+          </button>
+          <button
+            type="button"
+            onClick={() => onSearchModeChange('local')}
+            className="flex items-center gap-1 px-3 py-1.5 text-xs font-semibold transition-colors"
+            style={{
+              backgroundColor: searchMode === 'local' ? COLORS.primary : 'transparent',
+              color: searchMode === 'local' ? '#fff' : COLORS.primary,
+            }}
+            title={t('statementFilters.searchModeLocalHint')}
+          >
+            <MonitorSmartphone size={12} />
+            {t('statementFilters.searchModeLocal')}
+          </button>
+        </div>
       </div>
 
       <div className="w-full mb-3">
-        <label className="block text-xs font-bold mb-1" style={{ color: COLORS.primary }}>
-          {t('statementFilters.searchLabel')}
-        </label>
         <input type="text" value={searchQuery}
           onChange={(e) => onSearchQueryChange(e.target.value)}
-          placeholder={t('statementFilters.searchPlaceholder')}
+          placeholder={
+            searchMode === 'global'
+              ? t('statementFilters.searchPlaceholderGlobal')
+              : t('statementFilters.searchPlaceholderLocal')
+          }
           className="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-opacity-50"
-          style={{ borderColor: COLORS.primary }}
+          style={{ borderColor: searchMode === 'global' ? COLORS.primary : COLORS.secondary }}
           {...focusStyle}
         />
         <p className="text-xs mt-1" style={{ color: COLORS.gray }}>
-          {t('statementFilters.searchHelper')}
+          {searchMode === 'global'
+            ? t('statementFilters.searchHelperGlobal')
+            : t('statementFilters.searchHelperLocal')}
         </p>
       </div>
 

--- a/src/statement/ui/StatementsList.tsx
+++ b/src/statement/ui/StatementsList.tsx
@@ -34,7 +34,6 @@ const StatementsTable: React.FC<{ onVerifyRecords?: (records: StatementRecord[])
   const { enqueueSnackbar } = useSnackbar();
 
   const [data, setData] = useState<StatementRecord[]>([]);
-  const [filteredData, setFilteredData] = useState<StatementRecord[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [selectedRows, setSelectedRows] = useState<StatementRecord[]>([]);
   const [weekSummary, setWeekSummary] = useState<WeekSummary | null>(null);
@@ -43,6 +42,7 @@ const StatementsTable: React.FC<{ onVerifyRecords?: (records: StatementRecord[])
   const [pagination, setPagination] = useState({ pageIndex: 0, pageSize: 20 });
   const [totalRows, setTotalRows] = useState(0);
   const [searchQuery, setSearchQuery] = useState<string>('');
+  const [searchMode, setSearchMode] = useState<'global' | 'local'>('global');
   const weekRange = useMemo(() => getWeekRange(year, week), [year, week]);
 
   const [editRecord, setEditRecord] = useState<StatementRecord | null>(null);
@@ -50,19 +50,16 @@ const StatementsTable: React.FC<{ onVerifyRecords?: (records: StatementRecord[])
 
   const handleStateUpdated = (updated: StatementRecord) => {
     setData(prev => prev.map(d => d.id === updated.id ? updated : d));
-    setFilteredData(prev => prev.map(d => d.id === updated.id ? updated : d));
     enqueueSnackbar(t('statementsList.stateUpdated', { keyref: updated.keyref, state: updated.state }), { variant: 'success' });
   };
 
   const handleRecordUpdated = (updated: StatementRecord) => {
     setData(prev => prev.map(d => d.id === updated.id ? updated : d));
-    setFilteredData(prev => prev.map(d => d.id === updated.id ? updated : d));
     setEditRecord(null);
   };
 
   const handleRecordDeleted = (id: number) => {
     setData(prev => prev.filter(d => d.id !== id));
-    setFilteredData(prev => prev.filter(d => d.id !== id));
     setSelectedRows(prev => prev.filter(d => d.id !== id));
     setTotalRows(prev => Math.max(0, prev - 1));
     setDeleteRecord(null);
@@ -71,7 +68,15 @@ const StatementsTable: React.FC<{ onVerifyRecords?: (records: StatementRecord[])
   const loadData = useCallback(async () => {
     try {
       setLoading(true);
-      const response: StatementsByWeekResponse = await fetchStatementsByWeek(week, year, pagination.pageIndex + 1, pagination.pageSize);
+      // In global mode with a search query, omit week so the backend searches across all weeks
+      const weekParam = (searchMode === 'global' && searchQuery.trim()) ? undefined : week;
+      const response: StatementsByWeekResponse = await fetchStatementsByWeek(
+        weekParam,
+        year,
+        pagination.pageIndex + 1,
+        pagination.pageSize,
+        searchMode === 'global' ? searchQuery : undefined
+      );
       setData(response.results);
       setWeekSummary(response.week_summary || null);
       setTotalRows(response.count);
@@ -80,45 +85,46 @@ const StatementsTable: React.FC<{ onVerifyRecords?: (records: StatementRecord[])
     } finally {
       setLoading(false);
     }
-  }, [enqueueSnackbar, pagination.pageIndex, pagination.pageSize, week, year, t]);
+  }, [enqueueSnackbar, pagination.pageIndex, pagination.pageSize, week, year, searchMode, searchQuery, t]);
+
+  const displayData = useMemo(() => {
+    if (searchMode !== 'local' || !searchQuery.trim()) return data;
+    const q = searchQuery.trim().toLowerCase();
+    return data.filter(item =>
+      (item.keyref        && item.keyref.toLowerCase().includes(q))        ||
+      (item.shipper_name  && item.shipper_name.toLowerCase().includes(q)) ||
+      (item.income        && String(item.income).toLowerCase().includes(q)) ||
+      (item.expense       && String(item.expense).toLowerCase().includes(q))
+    );
+  }, [data, searchMode, searchQuery]);
 
   useEffect(() => { loadData(); }, [loadData]);
-
-  useEffect(() => {
-    let filtered = [...data];
-    if (searchQuery) {
-      const query = searchQuery.toLowerCase();
-      filtered = filtered.filter(item =>
-        (item.keyref && item.keyref.toLowerCase().includes(query)) ||
-        (item.shipper_name && item.shipper_name.toLowerCase().includes(query))
-      );
-    }
-    setFilteredData(filtered);
-  }, [data, searchQuery]);
 
   const handleRowSelect = (row: StatementRecord) => {
     setSelectedRows(prev => prev.some(s => s.id === row.id) ? prev.filter(s => s.id !== row.id) : [...prev, row]);
   };
 
   const handleSelectAll = (selectAll: boolean) => {
-    setSelectedRows(selectAll ? [...filteredData] : []);
+    setSelectedRows(selectAll ? [...data] : []);
   };
 
   return (
     <Box sx={{ width: '100%', height: '100%' }}>
       <StatementFilters
         week={week} year={year} weekRange={weekRange} searchQuery={searchQuery}
+        searchMode={searchMode}
         onWeekChange={setWeek} onYearChange={setYear} onSearchQueryChange={setSearchQuery}
-        weekSummary={weekSummary} totalRecords={totalRows}
+        onSearchModeChange={setSearchMode}
+        weekSummary={weekSummary} totalRecords={searchMode === 'local' ? displayData.length : totalRows}
       />
       <StatementToolbar
-        data={filteredData} selectedRows={selectedRows}
+        data={displayData} selectedRows={selectedRows}
         onExportExcel={(data, filename) => { console.log('Export Excel:', data, filename); enqueueSnackbar(t('statementsList.exportExcelPending'), { variant: 'info' }); }}
         onExportPDF={(data, filename) => { console.log('Export PDF:', data, filename); enqueueSnackbar(t('statementsList.exportPDFPending'), { variant: 'info' }); }}
         onRefresh={loadData} onVerifyRecords={onVerifyRecords}
       />
       <StatementDataTable
-        data={filteredData} loading={loading} page={pagination.pageIndex}
+        data={displayData} loading={loading} page={pagination.pageIndex}
         rowsPerPage={pagination.pageSize} totalRows={totalRows} selectedRows={selectedRows}
         onPageChange={(p) => setPagination(prev => ({ ...prev, pageIndex: p }))}
         onRowsPerPageChange={(rpp) => setPagination({ pageIndex: 0, pageSize: rpp })}

--- a/src/summaryCost/data/SummaryCostRepository.ts
+++ b/src/summaryCost/data/SummaryCostRepository.ts
@@ -43,6 +43,9 @@ export class SummaryCostRepository implements SummaryCostRepositoryInterface {
 
         // Always set only_paid to false as requested by backend contract
         queryParams.append('only_paid', String(params.onlyPaid === true));
+        
+        // Add include_table_costs parameter
+        queryParams.append('include_table_costs', 'false');
 
         try {
             const response = await fetch(`${this.baseUrl}/summary-list/?${queryParams.toString()}`, {


### PR DESCRIPTION
Add UI and backend integration to edit fuel cost records: introduces a new EditCostFuelDialog component (with form, order search, distribution preview, validation and snackbar feedback) and a repository function updateCostFuel to call PUT /costfuels/{id_fuel}/. Wire the edit flow into resumeFuel (table and page) by adding an Edit button to rows and opening the dialog from ResumeFuel. Add i18n keys (EN/ES) for the edit dialog and new search mode strings. Enhance statements and search behavior: fetchStatementsByWeek now accepts undefined week and a search parameter; StatementFilters gains a global/local search mode toggle and icon; StatementsList adapts to global vs local search (removes filteredData state, adds displayData memo, handles pagination/search accordingly). Also update SummaryCostRepository to always include include_table_costs=false in query params. Small imports and icon additions were included where needed.