### PR TITLE
Add statement and summary exports

### DIFF
--- a/src/Home/ui/TableFilters.tsx
+++ b/src/Home/ui/TableFilters.tsx
@@ -179,6 +179,10 @@ export const TableFilters: React.FC<TableFiltersProps> = ({
         opacity: 0;
       }
       .filter-accordion-inner {
+        overflow: visible;
+        min-height: 0;
+      }
+      .filter-accordion-content.collapsed .filter-accordion-inner {
         overflow: hidden;
       }
 

--- a/src/i18n/locales/en/en_translation.json
+++ b/src/i18n/locales/en/en_translation.json
@@ -886,8 +886,8 @@
   "statementsList": {
     "errorLoading": "Error loading statements",
     "stateUpdated": "Statement {{keyref}} state updated to {{state}}",
-    "exportExcelPending": "Export to Excel functionality to be implemented",
-    "exportPDFPending": "Export to PDF functionality to be implemented"
+    "exportExcelSuccess": "Excel exported successfully!",
+    "exportPDFSuccess": "PDF report opened for printing!"
   },
   "verificationResultsDialog": {
     "title": "Verification Results",
@@ -1223,7 +1223,9 @@
       "next": "Next →",
       "page": "Page {{page}}",
       "recordsPerPage": "Records per page:"
-    }
+    },
+    "exportExcel": "Download as Excel (.xlsx)",
+    "exportPDF": "Print / Save as PDF"
   },
   "weekPicker": {
     "label": "Week",

--- a/src/i18n/locales/es/es_translation.json
+++ b/src/i18n/locales/es/es_translation.json
@@ -369,7 +369,7 @@
       "key_ref": "Orden #",
       "date": "Fecha",
       "income": "Ingreso",
-      "expense": "Gasto",
+      "expense": "Descuento de orden",
       "weight": "Peso",
       "distance": "Distancia",
       "status": "Estado",
@@ -710,7 +710,7 @@
     "name": "Nombre",
     "lastName": "Apellido",
     "additionalBonuses": "Bonos Adicionales",
-    "expenses": "Gastos",
+    "expenses": "Descuento de orden",
     "grandTotal": "Total General",
     "totalToPay": "Total a Pagar",
     "noResultsSearch": "No se encontraron operadores que coincidan con \"{{search}}\"",
@@ -822,7 +822,7 @@
     "week": "Semana",
     "shipper": "Transportista",
     "income": "Ingreso",
-    "expense": "Gasto",
+    "expense": "Descuento de Orden",
     "state": "Estado",
     "copyToClipboard": "Copiar al portapapeles",
     "copied": "¡Copiado!",
@@ -860,7 +860,7 @@
     "weekSummary": "Resumen de Semana",
     "records": "Registros",
     "income": "Ingreso",
-    "expense": "Gasto",
+    "expense": "Descuento de Orden",
     "net": "Neto",
     "statusBreakdown": "Desglose por Estado:",
     "stateNotExists": "No Existe",
@@ -887,8 +887,8 @@
   "statementsList": {
     "errorLoading": "Error al cargar estados de cuenta",
     "stateUpdated": "Estado de {{keyref}} actualizado a {{state}}",
-    "exportExcelPending": "Exportación a Excel pendiente de implementación",
-    "exportPDFPending": "Exportación a PDF pendiente de implementación"
+    "exportExcelSuccess": "¡Excel exportado exitosamente!",
+    "exportPDFSuccess": "¡Reporte PDF abierto para imprimir!"
   },
   "verificationResultsDialog": {
     "title": "Resultados de Verificación",
@@ -920,7 +920,7 @@
       "table": {
         "orderKey": "Clave de Orden",
         "income": "Ingreso",
-        "expense": "Gasto",
+        "expense": "Descuento de Orden",
         "date": "Fecha",
         "status": "Estado"
       }
@@ -1052,7 +1052,7 @@
       "thisWeek": "Esta Semana",
       "lastWeek": "Semana Anterior",
       "income": "Ingresos",
-      "expenses": "Gastos",
+      "expenses": "Descuento de orden",
       "profit": "Ganancia",
       "tooltipOrders": "Órdenes",
       "tooltipAmount": "Monto"
@@ -1231,7 +1231,9 @@
       "next": "Siguiente →",
       "page": "Página {{page}}",
       "recordsPerPage": "Registros por página:"
-    }
+    },
+    "exportExcel": "Descargar como Excel (.xlsx)",
+    "exportPDF": "Imprimir / Guardar como PDF"
   },
   "weekPicker": {
     "label": "Semana",
@@ -1388,7 +1390,7 @@
       "status": "Estado",
       "customer": "Cliente",
       "income": "Ingreso",
-      "expense": "Gasto",
+      "expense": "Descuento de orden",
       "totalCost": "Costo total"
     },
     "expand": {
@@ -1409,7 +1411,7 @@
       "customer": "Cliente",
       "customerFactory": "Empresa cliente",
       "income": "Ingreso",
-      "expense": "Gasto",
+      "expense": "Descuento de orden",
       "netProfit": "Ganancia neta",
       "summaryBreakdown": "Desglose de costos",
       "fuelCost": "Costo de gasolina",
@@ -1549,7 +1551,7 @@
       "orderId": "ID de Orden",
       "email": "Correo",
       "distance": "Distancia",
-      "expense": "Gasto",
+      "expense": "Descuento de orden",
       "income": "Ingreso",
       "extraCostDetails": "Detalles del Costo Extra",
       "id": "ID",
@@ -1587,7 +1589,7 @@
     "columns": {
       "reference": "Referencia",
       "client": "Cliente",
-      "expense": "Gasto",
+      "expense": "Descuento de orden",
       "fuelCost": "Costo Combustible",
       "bonus": "Bono",
       "operatorSalaries": "Salarios Operadores",
@@ -1603,7 +1605,7 @@
     "unpaid": "Pendiente",
     "view": "Ver",
     "income": "Ingreso",
-    "expense": "Gasto",
+    "expense": "Descuento de orden",
     "edit": "Editar",
     "netProfit": "Ganancia Neta",
     "costBreakdown": "Desglose de Costos",
@@ -1653,7 +1655,7 @@
     "total": "Total",
     "perOrder": "Por Orden",
     "income": "Ingreso",
-    "expense": "Gasto"
+    "expense": "Descuento de orden"
   },
   "financialView": {
     "title": "Resumen Financiero",
@@ -1687,19 +1689,19 @@
     },
     "addAmount": {
       "income": "Ingreso",
-      "expense": "Gasto",
+      "expense": "Descuento de orden",
       "success": "{{type}} agregado exitosamente a {{count}} orden(es)",
       "noOrdersUpdated": "Ninguna orden fue actualizada",
       "error": "Error al agregar {{type}}: {{message}}"
     }
   },
   "expenseBreakdown": {
-    "title": "Desglose de Gastos",
+    "title": "Desglose de Descuentos de Orden",
     "subtitle": "Selecciona un período a continuación. El desglose mostrará los datos del rango seleccionado. Usa los botones rápidos para períodos estándar o personaliza tu propio rango.",
     "back": "Volver al Resumen Financiero",
     "actions": {
       "refresh": "Actualizar",
-      "createCost": "Crear Gasto",
+      "createCost": "Crear Descuento de Orden",
       "createIncome": "Crear Ingreso",
       "export": "Exportar / Imprimir"
     },
@@ -1744,7 +1746,7 @@
       "variableFromDb": "Costos Variables de Base de Datos"
     },
     "expenseTypes": {
-      "expense": "Gasto",
+      "expense": "Descuento de orden",
       "fuelCost": "Combustible",
       "workCost": "Costos Extra",
       "bonus": "Bonificación",

--- a/src/statement/ui/StatementsList.tsx
+++ b/src/statement/ui/StatementsList.tsx
@@ -7,6 +7,7 @@ import { StatementFilters } from './StatementFilters';
 import { StatementToolbar } from './StatementToolbar';
 import { StatementDataTable } from './StatementDataTable';
 import { fetchStatementsByWeek } from '../data/StatementRepository';
+import { StatementExportUtils } from '../util/StatementExportUtils';
 import { StatementRecord, StatementsByWeekResponse, WeekSummary } from '../domain/StatementModels';
 import EditStatementDialog from './EditStatementDialog';
 import DeleteStatementDialog from './DeleteStatementDialog';
@@ -119,8 +120,8 @@ const StatementsTable: React.FC<{ onVerifyRecords?: (records: StatementRecord[])
       />
       <StatementToolbar
         data={displayData} selectedRows={selectedRows}
-        onExportExcel={(data, filename) => { console.log('Export Excel:', data, filename); enqueueSnackbar(t('statementsList.exportExcelPending'), { variant: 'info' }); }}
-        onExportPDF={(data, filename) => { console.log('Export PDF:', data, filename); enqueueSnackbar(t('statementsList.exportPDFPending'), { variant: 'info' }); }}
+        onExportExcel={(data, filename) => { StatementExportUtils.exportToExcel(data, filename); }}
+        onExportPDF={(data, filename) => { StatementExportUtils.exportToPDF(data, filename, week, year); }}
         onRefresh={loadData} onVerifyRecords={onVerifyRecords}
       />
       <StatementDataTable

--- a/src/statement/util/StatementExportUtils.ts
+++ b/src/statement/util/StatementExportUtils.ts
@@ -1,0 +1,282 @@
+import { StatementRecord } from '../domain/StatementModels';
+import { enqueueSnackbar } from 'notistack';
+
+export interface StatementExportData {
+  'Reference': string;
+  'Date': string;
+  'Week': number;
+  'Shipper': string;
+  'Income': number;
+  'Expense': number;
+  'State': string;
+  'Company': string;
+}
+
+export class StatementExportUtils {
+
+  static prepareExportData(records: StatementRecord[]): StatementExportData[] {
+    return records.map(record => ({
+      'Reference': record.keyref,
+      'Date': record.date,
+      'Week': record.week,
+      'Shipper': record.shipper_name || 'N/A',
+      'Income': parseFloat(record.income || '0'),
+      'Expense': parseFloat(record.expense || '0'),
+      'State': record.state || 'N/A',
+      'Company': record.company || 'N/A',
+    }));
+  }
+
+  static async exportToExcel(
+    data: StatementRecord[],
+    filename: string
+  ): Promise<void> {
+    try {
+      const XLSX = await import('xlsx');
+
+      const exportData = this.prepareExportData(data);
+
+      const totalsRow = {
+        'Reference': 'TOTALS',
+        'Date': `${exportData.length} records`,
+        'Week': 0,
+        'Shipper': '',
+        'Income': exportData.reduce((sum, row) => sum + row.Income, 0),
+        'Expense': exportData.reduce((sum, row) => sum + row.Expense, 0),
+        'State': '',
+        'Company': `Net: $${(exportData.reduce((sum, row) => sum + row.Income, 0) - exportData.reduce((sum, row) => sum + row.Expense, 0)).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
+      };
+
+      const dataWithTotals = [...exportData, totalsRow];
+
+      const ws = XLSX.utils.json_to_sheet(dataWithTotals);
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, 'Statements');
+
+      const colWidths = [
+        { wch: 18 },
+        { wch: 14 },
+        { wch: 8 },
+        { wch: 25 },
+        { wch: 15 },
+        { wch: 15 },
+        { wch: 15 },
+        { wch: 25 },
+      ];
+      ws['!cols'] = colWidths;
+
+      const range = XLSX.utils.decode_range(ws['!ref'] || 'A1');
+
+      for (let col = range.s.c; col <= range.e.c; col++) {
+        const cellAddress = XLSX.utils.encode_cell({ r: 0, c: col });
+        if (ws[cellAddress]) {
+          ws[cellAddress].s = {
+            font: { bold: true, color: { rgb: 'FFFFFF' }, sz: 12 },
+            fill: { fgColor: { rgb: '0B2863' } },
+            alignment: { horizontal: 'center', vertical: 'center' },
+          };
+        }
+      }
+
+      const totalRowIndex = range.e.r;
+      for (let col = range.s.c; col <= range.e.c; col++) {
+        const cellAddress = XLSX.utils.encode_cell({ r: totalRowIndex, c: col });
+        if (ws[cellAddress]) {
+          ws[cellAddress].s = {
+            font: { bold: true, color: { rgb: '0B2863' }, sz: 12 },
+            fill: { fgColor: { rgb: 'FFE67B' } },
+            alignment: { horizontal: 'center', vertical: 'center' },
+            border: {
+              top: { style: 'thick', color: { rgb: '0B2863' } },
+              bottom: { style: 'thick', color: { rgb: '0B2863' } },
+            },
+          };
+        }
+      }
+
+      XLSX.writeFile(wb, filename);
+
+      enqueueSnackbar('Excel exported successfully!', { variant: 'success' });
+    } catch (error) {
+      enqueueSnackbar('Error exporting to Excel', { variant: 'error' });
+      console.error('Excel export error:', error);
+    }
+  }
+
+  static exportToPDF(
+    data: StatementRecord[],
+    filename: string,
+    week?: number,
+    year?: number
+  ): void {
+    try {
+      const exportData = this.prepareExportData(data);
+      const totalIncome = exportData.reduce((sum, row) => sum + row.Income, 0);
+      const totalExpense = exportData.reduce((sum, row) => sum + row.Expense, 0);
+      const net = totalIncome - totalExpense;
+
+      const weekLabel = week && year ? `Week ${week}, ${year}` : 'All Records';
+      const dateRange = week && year
+        ? `${year}, Week ${week}`
+        : 'All available records';
+
+      const html = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Statements Report - ${dateRange}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      line-height: 1.4;
+      color: #1f2937;
+      background: white;
+      padding: 20px;
+    }
+    .print-buttons {
+      position: fixed;
+      top: 20px;
+      right: 20px;
+      z-index: 1000;
+      display: flex;
+      gap: 10px;
+    }
+    .btn {
+      padding: 12px 20px;
+      border: none;
+      border-radius: 6px;
+      cursor: pointer;
+      font-weight: 600;
+      transition: all 0.2s ease;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+    .btn-print { background: #3b82f6; color: white; }
+    .btn-close { background: #6b7280; color: white; }
+    .btn:hover { transform: translateY(-1px); box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15); }
+    .report-container { max-width: 1400px; margin: 0 auto; background: white; border-radius: 12px; overflow: hidden; }
+    .header { background: linear-gradient(135deg, #0B2863, #1e40af); color: white; padding: 40px; text-align: center; }
+    .title { font-size: 32px; font-weight: 700; margin-bottom: 10px; }
+    .subtitle { font-size: 16px; opacity: 0.9; margin-bottom: 8px; }
+    .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 20px; padding: 40px; background: #f8fafc; }
+    .stat-box { background: white; padding: 20px; border-radius: 12px; text-align: center; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); border: 2px solid #e5e7eb; }
+    .stat-value { font-size: 24px; font-weight: 700; margin-bottom: 8px; }
+    .stat-label { font-size: 12px; color: #6b7280; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+    .content { padding: 40px; }
+    .section-title { font-size: 24px; font-weight: 700; margin-bottom: 20px; color: #1f2937; border-bottom: 3px solid #3b82f6; padding-bottom: 10px; }
+    table { width: 100%; border-collapse: collapse; margin: 20px 0; background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); font-size: 11px; }
+    th { background: #3b82f6; color: white; padding: 12px 8px; text-align: left; font-weight: 600; font-size: 11px; text-transform: uppercase; letter-spacing: 0.3px; }
+    td { padding: 8px; border-bottom: 1px solid #e5e7eb; font-size: 10px; }
+    tr:nth-child(even) { background: #f8fafc; }
+    .totals-row { background: #fef3c7 !important; font-weight: 700; border-top: 3px solid #0B2863; }
+    .no-data { text-align: center; padding: 40px; color: #6b7280; font-style: italic; }
+    @media print {
+      .print-buttons { display: none !important; }
+      body { margin: 0; padding: 0; }
+      .report-container { box-shadow: none; }
+      table { page-break-inside: avoid; font-size: 10px; }
+      th { background: #3b82f6 !important; -webkit-print-color-adjust: exact; font-size: 10px; }
+      .totals-row { background: #fef3c7 !important; -webkit-print-color-adjust: exact; }
+    }
+  </style>
+</head>
+<body>
+  <div class="print-buttons">
+    <button onclick="window.print()" class="btn btn-print">Print / Save as PDF</button>
+    <button onclick="window.close()" class="btn btn-close">Close</button>
+  </div>
+
+  <div class="report-container">
+    <div class="header">
+      <div class="title">STATEMENTS REPORT</div>
+      <div class="subtitle">${weekLabel}</div>
+      <div class="subtitle">Generated on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()}</div>
+    </div>
+
+    <div class="stats">
+      <div class="stat-box">
+        <div class="stat-value" style="color: #3b82f6;">${exportData.length}</div>
+        <div class="stat-label">Total Records</div>
+      </div>
+      <div class="stat-box">
+        <div class="stat-value" style="color: #22c55e;">$${totalIncome.toLocaleString('en-US', { minimumFractionDigits: 2 })}</div>
+        <div class="stat-label">Total Income</div>
+      </div>
+      <div class="stat-box">
+        <div class="stat-value" style="color: #ef4444;">$${totalExpense.toLocaleString('en-US', { minimumFractionDigits: 2 })}</div>
+        <div class="stat-label">Total Expense</div>
+      </div>
+      <div class="stat-box">
+        <div class="stat-value" style="color: ${net >= 0 ? '#22c55e' : '#ef4444'};">$${net.toLocaleString('en-US', { minimumFractionDigits: 2 })}</div>
+        <div class="stat-label">Net Amount</div>
+      </div>
+    </div>
+
+    <div class="content">
+      <div class="section-title">Statement Records</div>
+      ${exportData.length > 0 ? `
+      <table>
+        <thead>
+          <tr>
+            <th>Reference</th>
+            <th>Date</th>
+            <th>Week</th>
+            <th>Shipper</th>
+            <th>Income</th>
+            <th>Expense</th>
+            <th>State</th>
+            <th>Company</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${exportData.map(row => `
+            <tr>
+              <td><strong>${row['Reference']}</strong></td>
+              <td>${row['Date']}</td>
+              <td>${row['Week']}</td>
+              <td>${row['Shipper']}</td>
+              <td>$${row['Income'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Expense'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>${row['State']}</td>
+              <td>${row['Company']}</td>
+            </tr>
+          `).join('')}
+          <tr class="totals-row">
+            <td colspan="3"><strong>TOTALS — ${exportData.length} records</strong></td>
+            <td></td>
+            <td><strong>$${totalIncome.toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${totalExpense.toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td></td>
+            <td><strong>Net: $${net.toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+          </tr>
+        </tbody>
+      </table>
+      ` : `
+      <div class="no-data">
+        <h3>No statement records found</h3>
+        <p>There are no records available for the selected criteria.</p>
+      </div>
+      `}
+    </div>
+  </div>
+</body>
+</html>`;
+
+      const reportWindow = window.open('', '_blank');
+      if (!reportWindow) {
+        enqueueSnackbar('Please allow popups to view the report', { variant: 'warning' });
+        return;
+      }
+
+      reportWindow.document.write(html);
+      reportWindow.document.close();
+      reportWindow.focus();
+
+      enqueueSnackbar('PDF report opened for printing!', { variant: 'success' });
+    } catch (error) {
+      console.error('PDF export error:', error);
+      enqueueSnackbar('Error opening PDF report', { variant: 'error' });
+    }
+  }
+}

--- a/src/summaryCost/ui/pages/SummaryCost.tsx
+++ b/src/summaryCost/ui/pages/SummaryCost.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { FileSpreadsheet, FileText } from 'lucide-react';
 import { SummaryCostService } from '../../data/SummaryCostService';
 import { PaginatedOrderSummaryResult } from '../../domain/OrderSummaryModel';
 import { SummaryCostParams } from '../../data/SummaryCostRepository';
+import { SummaryCostExportUtils } from '../../util/SummaryCostExportUtils';
 import WeekPicker from '../../../components/WeekPicker';
 import YearPicker from '../../../components/YearPicker';
 import SummaryCostDataTable from '../components/SummaryCostDataTable';
@@ -32,20 +34,28 @@ const SummaryCost: React.FC = () => {
   const [page,         setPage]         = useState<number>(0);
   const [rowsPerPage,  setRowsPerPage]  = useState<number>(25);
   const [searchTerm,   setSearchTerm]   = useState<string>('');
+  const [isExporting,  setIsExporting]  = useState<boolean>(false);
 
   const summaryCostService = useMemo(() => new SummaryCostService(), []);
 
-  const fetchSummaryCost = useCallback(async (pageNum?: number, pageSize?: number, search?: string) => {
+  const doFetch = useCallback(async (overrides: {
+    pageNum?: number; pageSize?: number; search?: string;
+    yearVal?: number; weekVal?: number; startWeekVal?: number; endWeekVal?: number; modeVal?: 'single_week' | 'week_range';
+  } = {}) => {
+    const y  = overrides.yearVal  ?? year;
+    const m  = overrides.modeVal  ?? mode;
+    const pg = (overrides.pageNum ?? page) + 1;
+    const ps = overrides.pageSize ?? rowsPerPage;
+    const s  = overrides.search?.trim() || undefined;
+
     try {
       setIsLoading(true);
-      const params: SummaryCostParams = {
-        page: (pageNum ?? page) + 1,
-        pageSize: pageSize ?? rowsPerPage,
-        year, mode, onlyPaid: false,
-        search: search?.trim() ? search.trim() : undefined
-      };
-      if (mode === 'single_week') { params.numberWeek = week; }
-      else { params.startWeek = startWeek; params.endWeek = endWeek; }
+      const params: SummaryCostParams = { page: pg, pageSize: ps, year: y, mode: m, onlyPaid: false, search: s };
+      if (m === 'single_week') { params.numberWeek = overrides.weekVal ?? week; }
+      else {
+        params.startWeek = overrides.startWeekVal ?? startWeek;
+        params.endWeek   = overrides.endWeekVal   ?? endWeek;
+      }
       const response = await summaryCostService.getSummaryCost(params);
       setSummaryCost(response);
     } catch (error) {
@@ -54,19 +64,46 @@ const SummaryCost: React.FC = () => {
     } finally {
       setIsLoading(false);
     }
-  }, [page, rowsPerPage, year, week, mode, startWeek, endWeek, summaryCostService]);
+  }, [summaryCostService, year, mode, page, rowsPerPage, week, startWeek, endWeek]);
 
-  useEffect(() => { fetchSummaryCost(0, 25); }, [fetchSummaryCost]);
+  useEffect(() => { doFetch({ pageNum: 0, pageSize: 25 }); }, []);
 
-  const handleWeekChange        = useCallback((v: number) => { setWeek(v);      setPage(0); fetchSummaryCost(0, rowsPerPage, searchTerm); }, [rowsPerPage, searchTerm, fetchSummaryCost]);
-  const handleYearChange        = useCallback((v: number) => { setYear(v);      setPage(0); fetchSummaryCost(0, rowsPerPage, searchTerm); }, [rowsPerPage, searchTerm, fetchSummaryCost]);
-  const handleStartWeekChange   = useCallback((v: number) => { setStartWeek(v); setPage(0); fetchSummaryCost(0, rowsPerPage, searchTerm); }, [rowsPerPage, searchTerm, fetchSummaryCost]);
-  const handleEndWeekChange     = useCallback((v: number) => { setEndWeek(v);   setPage(0); fetchSummaryCost(0, rowsPerPage, searchTerm); }, [rowsPerPage, searchTerm, fetchSummaryCost]);
-  const handleSearchChange      = useCallback((s: string) => { setSearchTerm(s); setPage(0); fetchSummaryCost(0, rowsPerPage, s); }, [rowsPerPage, fetchSummaryCost]);
-  const handlePageChange        = useCallback((p: number) => { setPage(p); fetchSummaryCost(p, rowsPerPage, searchTerm); }, [rowsPerPage, searchTerm, fetchSummaryCost]);
-  const handleRowsPerPageChange = useCallback((r: number) => { setRowsPerPage(r); setPage(0); fetchSummaryCost(0, r, searchTerm); }, [searchTerm, fetchSummaryCost]);
+  const handleWeekChange        = useCallback((v: number) => { setWeek(v);      setPage(0); doFetch({ pageNum: 0, weekVal: v }); }, [doFetch]);
+  const handleYearChange        = useCallback((v: number) => { setYear(v);      setPage(0); doFetch({ pageNum: 0, yearVal: v }); }, [doFetch]);
+  const handleStartWeekChange   = useCallback((v: number) => { setStartWeek(v); setPage(0); doFetch({ pageNum: 0, startWeekVal: v }); }, [doFetch]);
+  const handleEndWeekChange     = useCallback((v: number) => { setEndWeek(v);   setPage(0); doFetch({ pageNum: 0, endWeekVal: v }); }, [doFetch]);
+  const handleSearchChange      = useCallback((s: string) => { setSearchTerm(s); setPage(0); doFetch({ pageNum: 0, search: s }); }, [doFetch]);
+  const handlePageChange        = useCallback((p: number) => { setPage(p); doFetch({ pageNum: p }); }, [doFetch]);
+  const handleRowsPerPageChange = useCallback((r: number) => { setRowsPerPage(r); setPage(0); doFetch({ pageNum: 0, pageSize: r }); }, [doFetch]);
 
   const handleContextMenu     = (event: React.MouseEvent, row: any) => { event.preventDefault(); console.log('Context menu for:', row); };
+
+  const handleExportExcel = async () => {
+    if (!summaryCost?.results?.length) return;
+    setIsExporting(true);
+    try {
+      await SummaryCostExportUtils.exportToExcel(
+        summaryCost.results, mode, year,
+        mode === 'single_week' ? week : undefined,
+        mode === 'week_range' ? startWeek : undefined,
+        mode === 'week_range' ? endWeek : undefined
+      );
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const handleExportPDF = () => {
+    if (!summaryCost?.results?.length) return;
+    SummaryCostExportUtils.exportToPDF(
+      summaryCost.results, mode, year,
+      mode === 'single_week' ? week : undefined,
+      mode === 'week_range' ? startWeek : undefined,
+      mode === 'week_range' ? endWeek : undefined
+    );
+  };
+
+  const exportDisabled = isExporting || !summaryCost?.results?.length;
 
   const totalPages   = summaryCost ? Math.ceil(summaryCost.count / rowsPerPage) : 0;
   const isLastPage   = page >= totalPages - 1;
@@ -97,11 +134,43 @@ const SummaryCost: React.FC = () => {
     <div className="container mx-auto p-4">
 
       {/* Header */}
-      <div className="mb-6">
-        <h1 className="text-2xl font-bold mb-2" style={{ color: '#0B2863' }}>
-          {t('summaryCost.title')}
-        </h1>
-        <p className="text-gray-600 text-sm">{t('summaryCost.subtitle')}</p>
+      <div className="mb-6 flex items-start justify-between flex-wrap gap-4">
+        <div>
+          <h1 className="text-2xl font-bold mb-2" style={{ color: '#0B2863' }}>
+            {t('summaryCost.title')}
+          </h1>
+          <p className="text-gray-600 text-sm">{t('summaryCost.subtitle')}</p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleExportExcel}
+            disabled={exportDisabled}
+            className="px-4 py-2 rounded-lg text-sm font-semibold transition-all duration-200 flex items-center gap-2"
+            style={{
+              background: exportDisabled ? '#e5e7eb' : 'linear-gradient(135deg, #22c55e 0%, #16a34a 100%)',
+              color: exportDisabled ? '#9ca3af' : '#fff',
+              cursor: exportDisabled ? 'not-allowed' : 'pointer',
+            }}
+            title={isExporting ? 'Exporting...' : t('summaryCost.exportExcel')}
+          >
+            <FileSpreadsheet size={16} />
+            {isExporting ? '...' : 'Excel'}
+          </button>
+          <button
+            onClick={handleExportPDF}
+            disabled={exportDisabled}
+            className="px-4 py-2 rounded-lg text-sm font-semibold transition-all duration-200 flex items-center gap-2"
+            style={{
+              background: exportDisabled ? '#e5e7eb' : 'linear-gradient(135deg, #ef4444 0%, #dc2626 100%)',
+              color: exportDisabled ? '#9ca3af' : '#fff',
+              cursor: exportDisabled ? 'not-allowed' : 'pointer',
+            }}
+            title={t('summaryCost.exportPDF')}
+          >
+            <FileText size={16} />
+            PDF
+          </button>
+        </div>
       </div>
 
       {/* Filters */}

--- a/src/summaryCost/util/SummaryCostExportUtils.ts
+++ b/src/summaryCost/util/SummaryCostExportUtils.ts
@@ -1,0 +1,330 @@
+import { OrderSummary } from '../domain/OrderSummaryModel';
+import { enqueueSnackbar } from 'notistack';
+
+export interface SummaryCostExportData {
+  'Reference': string;
+  'Client': string;
+  'Customer Factory': string;
+  'Date': string;
+  'State': string;
+  'Status': string;
+  'Pay Status': string;
+  'Income': number;
+  'Expense': number;
+  'Fuel Cost': number;
+  'Work Cost': number;
+  'Driver Salaries': number;
+  'Other Salaries': number;
+  'Bonus': number;
+  'Total Cost': number;
+  'Net Profit': number;
+}
+
+function parseLocalDate(s: string): Date {
+  const [y, m, d] = s.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export class SummaryCostExportUtils {
+
+  static prepareExportData(orders: OrderSummary[]): SummaryCostExportData[] {
+    return orders.map(order => ({
+      'Reference': order.key_ref,
+      'Client': order.client,
+      'Customer Factory': order.customer_name || 'N/A',
+      'Date': parseLocalDate(order.date).toLocaleDateString(),
+      'State': order.state,
+      'Status': (order.status || 'N/A').charAt(0).toUpperCase() + (order.status || 'N/A').slice(1),
+      'Pay Status': order.payStatus === 1 ? 'Paid' : order.payStatus === 0 ? 'Unpaid' : 'N/A',
+      'Income': order.summary?.rentingCost ?? order.income ?? 0,
+      'Expense': order.summary?.expense ?? 0,
+      'Fuel Cost': order.summary?.fuelCost ?? 0,
+      'Work Cost': order.summary?.workCost ?? 0,
+      'Driver Salaries': order.summary?.driverSalaries ?? 0,
+      'Other Salaries': order.summary?.otherSalaries ?? 0,
+      'Bonus': order.summary?.bonus ?? 0,
+      'Total Cost': order.summary?.totalCost ?? 0,
+      'Net Profit': order.summary?.net_profit ?? 0,
+    }));
+  }
+
+  static generateFileName(
+    mode: 'single_week' | 'week_range',
+    year: number,
+    week?: number,
+    startWeek?: number,
+    endWeek?: number
+  ): string {
+    if (mode === 'single_week') {
+      return `summary_cost_week_${week}_${year}.xlsx`;
+    }
+    return `summary_cost_range_${startWeek}-${endWeek}_${year}.xlsx`;
+  }
+
+  static async exportToExcel(
+    orders: OrderSummary[],
+    mode: 'single_week' | 'week_range',
+    year: number,
+    week?: number,
+    startWeek?: number,
+    endWeek?: number
+  ): Promise<void> {
+    try {
+      const XLSX = await import('xlsx');
+
+      const exportData = this.prepareExportData(orders);
+
+      const totalsRow: SummaryCostExportData = {
+        'Reference': 'TOTALS',
+        'Client': `${exportData.length} orders`,
+        'Customer Factory': '',
+        'Date': '',
+        'State': '',
+        'Status': `Paid: ${orders.filter(o => o.payStatus === 1).length} | Unpaid: ${orders.filter(o => o.payStatus === 0).length}`,
+        'Pay Status': '',
+        'Income': exportData.reduce((sum, r) => sum + r.Income, 0),
+        'Expense': exportData.reduce((sum, r) => sum + r.Expense, 0),
+        'Fuel Cost': exportData.reduce((sum, r) => sum + r['Fuel Cost'], 0),
+        'Work Cost': exportData.reduce((sum, r) => sum + r['Work Cost'], 0),
+        'Driver Salaries': exportData.reduce((sum, r) => sum + r['Driver Salaries'], 0),
+        'Other Salaries': exportData.reduce((sum, r) => sum + r['Other Salaries'], 0),
+        'Bonus': exportData.reduce((sum, r) => sum + r.Bonus, 0),
+        'Total Cost': exportData.reduce((sum, r) => sum + r['Total Cost'], 0),
+        'Net Profit': exportData.reduce((sum, r) => sum + r['Net Profit'], 0),
+      };
+
+      const dataWithTotals = [...exportData, totalsRow];
+
+      const ws = XLSX.utils.json_to_sheet(dataWithTotals);
+      const wb = XLSX.utils.book_new();
+      XLSX.utils.book_append_sheet(wb, ws, 'Summary Cost');
+
+      const cols = Object.keys(dataWithTotals[0] || {});
+      const colWidths = cols.map(key =>
+        key === 'Reference' || key === 'Customer Factory' ? { wch: 20 }
+          : key.length > 10 ? { wch: key.length + 4 }
+            : { wch: 16 }
+      );
+      ws['!cols'] = colWidths;
+
+      const range = XLSX.utils.decode_range(ws['!ref'] || 'A1');
+
+      for (let col = range.s.c; col <= range.e.c; col++) {
+        const cellAddress = XLSX.utils.encode_cell({ r: 0, c: col });
+        if (ws[cellAddress]) {
+          ws[cellAddress].s = {
+            font: { bold: true, color: { rgb: 'FFFFFF' }, sz: 12 },
+            fill: { fgColor: { rgb: '0B2863' } },
+            alignment: { horizontal: 'center', vertical: 'center' },
+          };
+        }
+      }
+
+      const totalRowIndex = range.e.r;
+      for (let col = range.s.c; col <= range.e.c; col++) {
+        const cellAddress = XLSX.utils.encode_cell({ r: totalRowIndex, c: col });
+        if (ws[cellAddress]) {
+          ws[cellAddress].s = {
+            font: { bold: true, color: { rgb: '0B2863' }, sz: 12 },
+            fill: { fgColor: { rgb: 'FFE67B' } },
+            alignment: { horizontal: 'center', vertical: 'center' },
+            border: {
+              top: { style: 'thick', color: { rgb: '0B2863' } },
+              bottom: { style: 'thick', color: { rgb: '0B2863' } },
+            },
+          };
+        }
+      }
+
+      const fileName = this.generateFileName(mode, year, week, startWeek, endWeek);
+      XLSX.writeFile(wb, fileName);
+
+      enqueueSnackbar('Excel exported successfully!', { variant: 'success' });
+    } catch (error) {
+      enqueueSnackbar('Error exporting to Excel', { variant: 'error' });
+      console.error('Excel export error:', error);
+    }
+  }
+
+  static exportToPDF(
+    orders: OrderSummary[],
+    mode: 'single_week' | 'week_range',
+    year: number,
+    week?: number,
+    startWeek?: number,
+    endWeek?: number
+  ): void {
+    try {
+      const exportData = this.prepareExportData(orders);
+      const totalIncome = exportData.reduce((sum, r) => sum + r.Income, 0);
+      const totalExpense = exportData.reduce((sum, r) => sum + r.Expense, 0);
+      const totalCost = exportData.reduce((sum, r) => sum + r['Total Cost'], 0);
+      const totalProfit = exportData.reduce((sum, r) => sum + r['Net Profit'], 0);
+
+      const dateLabel = mode === 'single_week'
+        ? `Year ${year}, Week ${week}`
+        : `Year ${year}, Weeks ${startWeek}-${endWeek}`;
+
+      const html = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Summary Cost Report - ${dateLabel}</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif; line-height: 1.4; color: #1f2937; background: white; padding: 20px; }
+    .print-buttons { position: fixed; top: 20px; right: 20px; z-index: 1000; display: flex; gap: 10px; }
+    .btn { padding: 12px 20px; border: none; border-radius: 6px; cursor: pointer; font-weight: 600; transition: all 0.2s ease; box-shadow: 0 2px 4px rgba(0,0,0,0.1); }
+    .btn-print { background: #3b82f6; color: white; }
+    .btn-close { background: #6b7280; color: white; }
+    .btn:hover { transform: translateY(-1px); box-shadow: 0 4px 8px rgba(0,0,0,0.15); }
+    .report-container { max-width: 100%; margin: 0 auto; background: white; border-radius: 12px; overflow: hidden; }
+    .header { background: linear-gradient(135deg, #0B2863, #1e40af); color: white; padding: 40px; text-align: center; }
+    .title { font-size: 32px; font-weight: 700; margin-bottom: 10px; }
+    .subtitle { font-size: 16px; opacity: 0.9; margin-bottom: 8px; }
+    .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 20px; padding: 40px; background: #f8fafc; }
+    .stat-box { background: white; padding: 20px; border-radius: 12px; text-align: center; box-shadow: 0 4px 6px rgba(0,0,0,0.1); border: 2px solid #e5e7eb; }
+    .stat-value { font-size: 24px; font-weight: 700; margin-bottom: 8px; }
+    .stat-label { font-size: 12px; color: #6b7280; font-weight: 600; text-transform: uppercase; letter-spacing: 0.5px; }
+    .content { padding: 40px; overflow-x: auto; }
+    .section-title { font-size: 24px; font-weight: 700; margin-bottom: 20px; color: #1f2937; border-bottom: 3px solid #3b82f6; padding-bottom: 10px; }
+    table { width: 100%; border-collapse: collapse; margin: 20px 0; background: white; border-radius: 8px; overflow: hidden; box-shadow: 0 4px 6px rgba(0,0,0,0.1); font-size: 10px; }
+    th { background: #3b82f6; color: white; padding: 10px 6px; text-align: left; font-weight: 600; font-size: 10px; text-transform: uppercase; letter-spacing: 0.3px; white-space: nowrap; }
+    td { padding: 6px; border-bottom: 1px solid #e5e7eb; font-size: 9px; white-space: nowrap; }
+    tr:nth-child(even) { background: #f8fafc; }
+    .totals-row { background: #fef3c7 !important; font-weight: 700; border-top: 3px solid #0B2863; }
+    .no-data { text-align: center; padding: 40px; color: #6b7280; font-style: italic; }
+    @media print {
+      .print-buttons { display: none !important; }
+      body { margin: 0; padding: 0; }
+      .report-container { box-shadow: none; }
+      table { page-break-inside: avoid; }
+      th { background: #3b82f6 !important; -webkit-print-color-adjust: exact; }
+      .totals-row { background: #fef3c7 !important; -webkit-print-color-adjust: exact; }
+    }
+  </style>
+</head>
+<body>
+  <div class="print-buttons">
+    <button onclick="window.print()" class="btn btn-print">🖨️ Print / Save as PDF</button>
+    <button onclick="window.close()" class="btn btn-close">✖️ Close</button>
+  </div>
+
+  <div class="report-container">
+    <div class="header">
+      <div class="title">SUMMARY COST REPORT</div>
+      <div class="subtitle">${dateLabel}</div>
+      <div class="subtitle">Generated on ${new Date().toLocaleDateString()} at ${new Date().toLocaleTimeString()}</div>
+    </div>
+
+    <div class="stats">
+      <div class="stat-box">
+        <div class="stat-value" style="color: #3b82f6;">${exportData.length}</div>
+        <div class="stat-label">Total Orders</div>
+      </div>
+      <div class="stat-box">
+        <div class="stat-value" style="color: #22c55e;">$${totalIncome.toLocaleString('en-US', { minimumFractionDigits: 2 })}</div>
+        <div class="stat-label">Total Income</div>
+      </div>
+      <div class="stat-box">
+        <div class="stat-value" style="color: #ef4444;">$${totalExpense.toLocaleString('en-US', { minimumFractionDigits: 2 })}</div>
+        <div class="stat-label">Total Expense</div>
+      </div>
+      <div class="stat-box">
+        <div class="stat-value" style="color: #6366f1;">$${totalCost.toLocaleString('en-US', { minimumFractionDigits: 2 })}</div>
+        <div class="stat-label">Total Cost</div>
+      </div>
+      <div class="stat-box">
+        <div class="stat-value" style="color: ${totalProfit >= 0 ? '#22c55e' : '#ef4444'};">$${totalProfit.toLocaleString('en-US', { minimumFractionDigits: 2 })}</div>
+        <div class="stat-label">Net Profit</div>
+      </div>
+    </div>
+
+    <div class="content">
+      <div class="section-title">Detailed Summary</div>
+      ${exportData.length > 0 ? `
+      <table>
+        <thead>
+          <tr>
+            <th>Reference</th>
+            <th>Client</th>
+            <th>Customer Factory</th>
+            <th>Date</th>
+            <th>State</th>
+            <th>Status</th>
+            <th>Pay Status</th>
+            <th>Income</th>
+            <th>Expense</th>
+            <th>Fuel Cost</th>
+            <th>Work Cost</th>
+            <th>Driver Salaries</th>
+            <th>Other Salaries</th>
+            <th>Bonus</th>
+            <th>Total Cost</th>
+            <th>Net Profit</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${exportData.map(row => `
+            <tr>
+              <td><strong>${row['Reference']}</strong></td>
+              <td>${row['Client']}</td>
+              <td>${row['Customer Factory']}</td>
+              <td>${row['Date']}</td>
+              <td>${row['State']}</td>
+              <td>${row['Status']}</td>
+              <td>${row['Pay Status']}</td>
+              <td>$${row['Income'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Expense'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Fuel Cost'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Work Cost'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Driver Salaries'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Other Salaries'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Bonus'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Total Cost'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+              <td>$${row['Net Profit'].toLocaleString('en-US', { minimumFractionDigits: 2 })}</td>
+            </tr>
+          `).join('')}
+          <tr class="totals-row">
+            <td colspan="7"><strong>TOTALS — ${exportData.length} orders</strong></td>
+            <td><strong>$${totalIncome.toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${totalExpense.toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${exportData.reduce((s, r) => s + r['Fuel Cost'], 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${exportData.reduce((s, r) => s + r['Work Cost'], 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${exportData.reduce((s, r) => s + r['Driver Salaries'], 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${exportData.reduce((s, r) => s + r['Other Salaries'], 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${exportData.reduce((s, r) => s + r['Bonus'], 0).toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${totalCost.toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+            <td><strong>$${totalProfit.toLocaleString('en-US', { minimumFractionDigits: 2 })}</strong></td>
+          </tr>
+        </tbody>
+      </table>
+      ` : `
+      <div class="no-data">
+        <h3>No summary cost data found</h3>
+        <p>There are no records available for the selected criteria.</p>
+      </div>
+      `}
+    </div>
+  </div>
+</body>
+</html>`;
+
+      const reportWindow = window.open('', '_blank');
+      if (!reportWindow) {
+        enqueueSnackbar('Please allow popups to view the report', { variant: 'warning' });
+        return;
+      }
+
+      reportWindow.document.write(html);
+      reportWindow.document.close();
+      reportWindow.focus();
+
+      enqueueSnackbar('PDF report opened for printing!', { variant: 'success' });
+    } catch (error) {
+      console.error('PDF export error:', error);
+      enqueueSnackbar('Error opening PDF report', { variant: 'error' });
+    }
+  }
+}


### PR DESCRIPTION
Implement real Excel and PDF export flows for statements and summary cost pages, including new export utility modules, updated toolbar actions, and success/error notifications. Also refresh related i18n strings and fix the table filter accordion overflow for the expanded content.